### PR TITLE
Add support for keyboard navigation for submenu item

### DIFF
--- a/src/Blazored.Menu/BlazoredSubMenu.razor
+++ b/src/Blazored.Menu/BlazoredSubMenu.razor
@@ -4,11 +4,11 @@
     <li class="@CssString" disabled="@(!IsEnabled)">
         @if (HeaderTemplate != null)
         {
-            <span @onclick="ToggleSubMenu">@HeaderTemplate <i>@Icon</i></span>
+            <span role="button" tabindex="0" @onclick="ToggleSubMenu" @onkeydown="KeyDownHandler">@HeaderTemplate <i>@Icon</i></span>
         }
         else
         {
-            <span @onclick="ToggleSubMenu">@Header <i>@Icon</i></span>
+            <span role="button" tabindex="0" @onclick="ToggleSubMenu" @onkeydown="KeyDownHandler">@Header <i>@Icon</i></span>
         }
 
         <ul class="blazored-sub-menu">

--- a/src/Blazored.Menu/BlazoredSubMenu.razor.cs
+++ b/src/Blazored.Menu/BlazoredSubMenu.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using System.Collections.Generic;
 
 namespace Blazored.Menu
@@ -34,5 +35,18 @@ namespace Blazored.Menu
             IsOpen = !IsOpen;
             Icon = IsOpen ? "-" : "+";
         }
+
+        /// <summary>
+        /// Handler for the key down events
+        /// </summary>
+        /// <param name="eventArgs">keyboard event</param>
+        protected void KeyDownHandler(KeyboardEventArgs eventArgs)
+        {
+            if (eventArgs.Key == "Enter" || eventArgs.Key == " " || eventArgs.Key == "Spacebar")
+            {
+                ToggleSubMenu();
+            }
+        }
+
     }
 }


### PR DESCRIPTION
This changes minor details in the BlazoredSubMenu implemenation to
support:
- keyboard based navigation (role and tabindex)
- keyboard based interaction (Enter key down)

~~As the support for event propagation in Blazor is not yet there, the
implementation marks support for SPACE keyboard as TODO item (supporting
SPACE from code requires cancelling propagation of the event in the
handler).~~

The changes do not impact samples details.

Thanks!

![blazor-menu](https://user-images.githubusercontent.com/14539/68083903-c47d2f80-fe2e-11e9-8fb9-208ea3ca3215.gif)
